### PR TITLE
Add some informations to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,10 @@ ads@NK:/home/ads/ndb/build$ make
 ## Integration
 ### CMake
 ```cmake 
-include_directories(${PATH_TO_NDB}/ndb/include)
-include_directories(${PATH_TO_NDB}/ndb/third_party/sqlite/include)
-include_directories(${PATH_TO_NDB}/ndb/third_party/boost)
-include_directories(${PATH_TO_NDB}/ndb/third_party/mpl/src)
-
 add_subdirectory(${PATH_TO_NDB}/ndb ${THIRD_PARTY_ROOT}/ndb/cmake-build)
-target_link_libraries(my_target INTERFACE lib_ndb)
+target_link_libraries(my_target lib_ndb)
 ```
-> Remember, it's importent to enable options like like engines **before** adding the subdirectory. Indeed, you need to include libraries of the engine you use.
-> Furthermore, if you have an other `target_link_libraries` in your CMakeLists.txt you **must** add a keyword like `LINK_PUBLIC`, `LINK_PRIVATE` or `INTERFACE`. If you don't, you will not be able to load your project. [See the officiel documentation](https://cmake.org/cmake/help/v3.0/policy/CMP0023.html)
+> Remember, it's importent to enable options like engines **before** adding the subdirectory. Indeed, you need to include libraries of the engine you use.
 
 ### Manual
 Add paths to ndb headers and your customs engine builds

--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ ads@NK:/home/ads/ndb/build$ make
 ## Integration
 ### CMake
 ```cmake 
+include_directories(${PATH_TO_NDB}/ndb/include)
+include_directories(${PATH_TO_NDB}/ndb/third_party/sqlite/include)
+include_directories(${PATH_TO_NDB}/third-party/ndb/third_party/boost)
+
 add_subdirectory(${PATH_TO_NDB}/ndb ${THIRD_PARTY_ROOT}/ndb/cmake-build)
 target_link_libraries(my_target INTERFACE lib_ndb)
-add_dependencies(my_target lib_ndb)
 ```
-> Remember, it's importent to enable options like like engines **before** adding the subdirectory. 
+> Remember, it's importent to enable options like like engines **before** adding the subdirectory. Indeed, you need to include libraries of the engine you use.
 > Furthermore, if you have an other `target_link_libraries` in your CMakeLists.txt you **must** add a keyword like `LINK_PUBLIC`, `LINK_PRIVATE` or `INTERFACE`. If you don't, you will not be able to load your project. [See the officiel documentation](https://cmake.org/cmake/help/v3.0/policy/CMP0023.html)
 
 ### Manual

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ ads@NK:/home/ads/ndb/build$ make
 ```cmake 
 include_directories(${PATH_TO_NDB}/ndb/include)
 include_directories(${PATH_TO_NDB}/ndb/third_party/sqlite/include)
-include_directories(${PATH_TO_NDB}/third-party/ndb/third_party/boost)
+include_directories(${PATH_TO_NDB}/ndb/third_party/boost)
+include_directories(${PATH_TO_NDB}/ndb/third_party/mpl/src)
 
 add_subdirectory(${PATH_TO_NDB}/ndb ${THIRD_PARTY_ROOT}/ndb/cmake-build)
 target_link_libraries(my_target INTERFACE lib_ndb)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ ads@NK:/home/ads/ndb/build$ make
 ```cmake 
 add_subdirectory(${PATH_TO_NDB}/ndb ${THIRD_PARTY_ROOT}/ndb/cmake-build)
 target_link_libraries(my_target INTERFACE lib_ndb)
+add_dependencies(my_target lib_ndb)
 ```
+> Remember, it's importent to enable options like like engines **before** adding the subdirectory. 
+> Furthermore, if you have an other `target_link_libraries` in your CMakeLists.txt you **must** add a keyword like `LINK_PUBLIC`, `LINK_PRIVATE` or `INTERFACE`. If you don't, you will not be able to load your project. [See the officiel documentation](https://cmake.org/cmake/help/v3.0/policy/CMP0023.html)
 
 ### Manual
 Add paths to ndb headers and your customs engine builds


### PR DESCRIPTION
I added some informations to the README in this section : 
```
## Integration
### CMake
```
To make a summary, I added a missing CMake property and warning about the options position and a possible load error.